### PR TITLE
feat(v2): add taskferry optimizer provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,29 @@ The current repository includes:
 | Meta-ARE Default ReAct Agent (`meta_are`) | Git repository | GAIA2 | End-to-end smoke experiments |
 
 V2 supports immutable, content-addressed component-map and Git candidate spaces. Optimizer sessions
-can use the built-in fake provider, Anthropic Claude Agent SDK, or GitHub Copilot SDK transport.
+can use the built-in fake provider, Anthropic Claude Agent SDK, GitHub Copilot SDK transport, or a
+TaskFerry-dispatch opencode/pi worker (`taskferry` provider).
+
+The `taskferry` provider runs each optimizer session as its own sandboxed TaskFerry task
+(`--no-overlay`, so the worker's writes land directly in the auto-generated session workspace),
+waits for settlement, and records the reported tokens and cost in the usage ledger. Configure it
+with the worker model inside `provider.settings`:
+
+```yaml
+provider:
+  type: taskferry
+  capabilities: [read_workspace, edit_workspace, run_commands, load_skills, network]
+  settings:
+    model: openai/gpt-5.6
+    variant: default
+    executor: opencode
+    sandboxed: true
+```
+
+`model` is required and must name a model the TaskFerry daemon can route (see TaskFerry's
+`choosing-a-model` conventions). `variant`, `executor` (`opencode` or `pi`), and `sandboxed`
+(default `true`) are optional. Sessions are dispatched with a `--class` of `autosaddler-v2` so
+they are identifiable in `taskferry list`.
 
 Integrations for additional harnesses (e.g., **OpenClaw** and **Codex**) and benchmarks (e.g., **Terminal-Bench**) are coming. Stay tuned!
 

--- a/src/autosaddler/v2/config/registry.py
+++ b/src/autosaddler/v2/config/registry.py
@@ -35,6 +35,7 @@ from autosaddler.v2.providers.copilot import (
     CopilotProviderConfig,
 )
 from autosaddler.v2.providers.fake import FakeAgentProvider, PaidWorkLedger
+from autosaddler.v2.providers.taskferry import TaskferryAgentProvider, TaskferryProviderConfig
 from autosaddler.v2.storage.local import LocalRunStore, TransitionHook
 
 _PROVIDER_SDK_DISTRIBUTIONS = {
@@ -135,6 +136,7 @@ def default_registry() -> Registry:
             "fake": lambda *, ledger, settings: _fake_provider(ledger, settings),
             "claude": _registered_claude_provider,
             "copilot": _registered_copilot_provider,
+            "taskferry": _registered_taskferry_provider,
         }
     )
     registry.task_selection["fixed"] = lambda *, batch_size, seed: FixedTaskSelectionPolicy(batch_size=batch_size)
@@ -217,6 +219,11 @@ def _registered_claude_provider(*, ledger, settings) -> ClaudeAgentProvider:
 def _registered_copilot_provider(*, ledger, settings) -> CopilotAgentProvider:
     del ledger
     return _copilot_provider(settings)
+
+
+def _registered_taskferry_provider(*, ledger, settings) -> TaskferryAgentProvider:
+    del ledger
+    return _taskferry_provider(settings)
 
 
 def build_runtime(
@@ -369,6 +376,22 @@ def _copilot_custom_provider(value: JsonValue | None) -> CopilotCustomProviderCo
     )
 
 
+def _taskferry_provider(settings: Mapping[str, JsonValue]) -> TaskferryAgentProvider:
+    expected = {"model", "variant", "executor", "sandboxed"}
+    missing = sorted({"model"} - settings.keys())
+    extra = sorted(settings.keys() - expected)
+    if missing or extra:
+        raise ValueError(f"Invalid keys at provider.settings for taskferry: missing={missing}, extra={extra}")
+    return TaskferryAgentProvider(
+        TaskferryProviderConfig(
+            model=_string(settings["model"], "provider.settings.model"),
+            variant=_optional_string(settings.get("variant"), "provider.settings.variant"),
+            executor=_optional_string(settings.get("executor"), "provider.settings.executor"),
+            sandboxed=_optional_bool(settings.get("sandboxed"), "provider.settings.sandboxed", default=True),
+        )
+    )
+
+
 def _resolved_entities(
     config: RunConfig,
     scenario: ScenarioComponents,
@@ -443,3 +466,11 @@ def _optional_string(value: JsonValue, path: str) -> str | None:
     if value is None:
         return None
     return _string(value, path)
+
+
+def _optional_bool(value: JsonValue, path: str, *, default: bool) -> bool:
+    if value is None:
+        return default
+    if not isinstance(value, bool):
+        raise TypeError(f"{path} must be a boolean")
+    return value

--- a/src/autosaddler/v2/providers/taskferry.py
+++ b/src/autosaddler/v2/providers/taskferry.py
@@ -1,0 +1,451 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+import time
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from autosaddler.v2.core.domain import JsonValue, to_json_value
+from autosaddler.v2.prompting.models import Usage
+from autosaddler.v2.providers.base import AgentTransport, BaseAgentProvider, TransportOutcome, observe_usage
+from autosaddler.v2.providers.workspace_renderer import RenderedSession, taskferry_renderer
+
+logger = logging.getLogger(__name__)
+
+_RESULT_FIELDS = (
+    "message,tokens,cost,sessionId,exitCode,signal,spawnError,failureReason,failureDetail,incomplete"
+)
+_SETTLED_STATUSES = frozenset({"done", "crashed", "cancelled", "unknown"})
+_UNSETTLED_STATUSES = frozenset({"queued", "running"})
+
+
+@dataclass(frozen=True, slots=True)
+class TaskferryProviderConfig:
+    model: str = "openai/gpt-5.6"
+    variant: str | None = None
+    executor: str | None = None
+    sandboxed: bool = True
+    executable: str = "taskferry"
+
+    def __post_init__(self) -> None:
+        for name in ("model", "executable"):
+            if not getattr(self, name):
+                raise ValueError(f"Taskferry {name} cannot be empty")
+        if self.executor is not None and self.executor not in ("opencode", "pi"):
+            raise ValueError(f"Taskferry executor must be 'opencode' or 'pi', got {self.executor!r}")
+
+
+class TaskferryAgentProvider(BaseAgentProvider):
+    def __init__(
+        self,
+        config: TaskferryProviderConfig | None = None,
+        *,
+        transport: AgentTransport | None = None,
+    ) -> None:
+        resolved_config = config or TaskferryProviderConfig()
+        super().__init__(taskferry_renderer(), transport or TaskferryCliTransport(resolved_config))
+
+
+class TaskferryCliTransport:
+    """Dispatch optimizer sessions through the taskferry CLI.
+
+    Every session is dispatched with ``--no-overlay`` so the worker's writes
+    land directly in the session workspace instead of a copy-on-write overlay
+    awaiting an accept step: the session workspace is AutoSaddler-owned
+    scratch space and the structured output file must be readable by the
+    engine immediately after settlement.
+    """
+
+    def __init__(self, config: TaskferryProviderConfig) -> None:
+        self.config = config
+
+    async def run(self, session: RenderedSession, timeout_seconds: float) -> TransportOutcome:
+        started_wall = time.monotonic()
+        payload = await self._dispatch(session)
+        task_id = payload.get("id")
+        if not isinstance(task_id, str) or not task_id:
+            raise RuntimeError(f"taskferry dispatch returned no task id: {payload!r}")
+        result_payload: Mapping[str, JsonValue] | None = None
+        error_summary: Mapping[str, JsonValue] | None = None
+        try:
+            status_payload = await self._run_cli(("wait", task_id, "--timeout", _wait_duration(timeout_seconds)))
+            status = str(status_payload.get("status") or "")
+            if status in _UNSETTLED_STATUSES:
+                raise TimeoutError(f"taskferry task {task_id} did not settle within {timeout_seconds:.0f}s")
+            result_payload = await self._run_cli(("result", task_id, "--fields", _RESULT_FIELDS))
+            status = str(result_payload.get("status") or "")
+            if status != "done":
+                raise RuntimeError(
+                    f"taskferry task {task_id} ended with status {status!r}: {_failure_detail(result_payload)}"
+                )
+        except BaseException as error:
+            error_summary = _error_summary(error)
+            await self._cancel_best_effort(task_id)
+            raise
+        finally:
+            if session.trace_dir is not None:
+                try:
+                    _export_taskferry_session_state(
+                        task_id=task_id,
+                        destination_root=session.trace_dir / "taskferry-session-state",
+                        config=self.config,
+                        result_payload=result_payload,
+                        error_summary=error_summary,
+                    )
+                except Exception:
+                    logger.warning("Failed to write taskferry trace export manifest", exc_info=True)
+        usage = _taskferry_usage(
+            result_payload.get("tokens"),
+            self.config,
+            duration_seconds=time.monotonic() - started_wall,
+            incomplete=result_payload.get("incomplete"),
+            session_id=_text(result_payload.get("sessionId")),
+        )
+        for item in usage:
+            observe_usage(item)
+        return TransportOutcome(
+            raw_response=_text(result_payload.get("message")) or "",
+            tool_calls=(),
+            usage=tuple(usage),
+            usage_streamed=True,
+        )
+
+    async def _dispatch(self, session: RenderedSession) -> Mapping[str, JsonValue]:
+        arguments: list[str] = [
+            "dispatch",
+            "--prompt",
+            "-",
+            "--directory",
+            str(session.workspace),
+            "--model",
+            self.config.model,
+            "--no-overlay",
+            "--class",
+            "autosaddler-v2",
+        ]
+        if self.config.variant is not None:
+            arguments.extend(("--variant", self.config.variant))
+        if self.config.executor is not None:
+            arguments.extend(("--executor", self.config.executor))
+        if not self.config.sandboxed:
+            arguments.append("--no-sandbox")
+        payload = await self._run_cli(tuple(arguments), stdin=_dispatch_prompt(session))
+        if not isinstance(payload, Mapping):
+            raise ValueError("taskferry dispatch returned a non-object response")
+        return payload
+
+    async def _run_cli(
+        self,
+        arguments: Sequence[str],
+        *,
+        stdin: str | None = None,
+    ) -> Mapping[str, JsonValue]:
+        process = await asyncio.create_subprocess_exec(
+            self.config.executable,
+            *arguments,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout_bytes, stderr_bytes = await process.communicate(input=None if stdin is None else stdin.encode("utf-8"))
+        stdout = stdout_bytes.decode("utf-8", errors="replace")
+        stderr = stderr_bytes.decode("utf-8", errors="replace")
+        if process.returncode != 0:
+            raise RuntimeError(
+                f"taskferry {' '.join(arguments)} failed (exit {process.returncode}): {stderr[-2000:]}"
+            )
+        return _decode_toon(stdout)
+
+    async def _cancel_best_effort(self, task_id: str) -> None:
+        try:
+            process = await asyncio.create_subprocess_exec(
+                self.config.executable,
+                "cancel",
+                task_id,
+                stdout=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.DEVNULL,
+            )
+            await process.wait()
+        except Exception:
+            logger.warning("Failed to cancel taskferry task %s", task_id, exc_info=True)
+
+
+def _dispatch_prompt(session: RenderedSession) -> str:
+    prompt = "\n\n".join(
+        part for part in (session.system_context.rstrip(), session.task_prompt.rstrip()) if part
+    )
+    return (
+        f"{prompt}\n\n"
+        "Follow `.autosaddler/session_output_schema.json` and write the final structured output "
+        "as a JSON object to `.autosaddler/session_output.json`.\n"
+    )
+
+
+def _wait_duration(timeout_seconds: float) -> str:
+    seconds = max(1, int(timeout_seconds))
+    return f"{seconds}s"
+
+
+def _failure_detail(payload: Mapping[str, JsonValue]) -> str:
+    fields = {
+        key: _text(payload.get(key))
+        for key in ("failureReason", "failureDetail", "spawnError", "exitCode", "signal")
+        if payload.get(key) is not None
+    }
+    if not fields:
+        return "no failure detail reported"
+    return " ".join(f"{key}={value}" for key, value in fields.items())
+
+
+def _error_summary(error: BaseException) -> dict[str, JsonValue]:
+    return {"error_type": type(error).__name__, "error": str(error)[:2_000]}
+
+
+def _taskferry_usage(
+    tokens: JsonValue | None,
+    config: TaskferryProviderConfig,
+    *,
+    duration_seconds: float | None = None,
+    incomplete: JsonValue | None = None,
+    session_id: str | None = None,
+) -> tuple[Usage, ...]:
+    if not isinstance(tokens, Mapping):
+        if tokens is not None:
+            logger.warning("Ignoring unsupported taskferry tokens payload of type %s", type(tokens).__name__)
+        return ()
+    cached_input = _int_or(_nested(tokens, "cacheRead"), _nested(tokens, "cache", "read"), 0)
+    cache_creation = _int_or(_nested(tokens, "cacheWrite"), _nested(tokens, "cache", "write"), 0)
+    reported_input = _int_or(_nested(tokens, "input"), 0)
+    output = _int_or(_nested(tokens, "output"), 0)
+    reasoning = _int_or(_nested(tokens, "reasoning"), 0)
+    provider_total = _int_or(_nested(tokens, "totalTokens"), _nested(tokens, "total"), None)
+    cost_value = _nested(tokens, "cost", "total")
+    if cost_value is None:
+        cost_value = _nested(tokens, "cost")
+    provider_cost = _float_or(cost_value)
+    uncached_input = reported_input + cache_creation
+    input_tokens = cached_input + uncached_input
+    incomplete_flag = bool(incomplete)
+    return (
+        Usage(
+            role="optimizer",
+            model=config.model,
+            input_tokens=input_tokens,
+            cached_input_tokens=cached_input,
+            uncached_input_tokens=uncached_input,
+            output_tokens=output,
+            reasoning_tokens=min(reasoning, output),
+            total_tokens=input_tokens + output,
+            provider_cost=provider_cost,
+            provider_cost_unit="usd" if provider_cost is not None else None,
+            duration_seconds=duration_seconds,
+            status="failed" if incomplete_flag else "success",
+            usage_incomplete=incomplete_flag,
+            provider_correlation_id=session_id,
+            input_token_semantics="excludes_cached_tokens",
+            provider_reported_input_tokens=reported_input,
+            provider_reported_total_tokens=provider_total,
+            total_tokens_is_inferred=provider_total is None,
+            configured_settings=_without_none(
+                {
+                    "model": config.model,
+                    "variant": config.variant,
+                    "executor": config.executor,
+                }
+            ),
+            provider_metadata=(
+                {"incomplete": True} if incomplete_flag else {}
+            ),
+        ),
+    )
+
+
+def _nested(value: Mapping[str, Any], *keys: str) -> JsonValue | None:
+    current: Any = value
+    for key in keys:
+        if not isinstance(current, Mapping):
+            return None
+        current = current.get(key)
+        if current is None:
+            return None
+    if isinstance(current, (str, int, float, bool)) or current is None:
+        return current
+    return None
+
+
+def _int_or(*values: JsonValue | None) -> int | None:
+    for value in values:
+        if isinstance(value, bool):
+            continue
+        if isinstance(value, int):
+            return value
+        if isinstance(value, float) and value.is_integer():
+            return int(value)
+    return None
+
+
+def _float_or(value: JsonValue | None) -> float | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None
+
+
+def _text(value: JsonValue | None) -> str | None:
+    if value is None:
+        return None
+    return str(value)
+
+
+def _without_none(values: Mapping[str, JsonValue | None]) -> dict[str, JsonValue]:
+    return {key: value for key, value in values.items() if value is not None}
+
+
+def _export_taskferry_session_state(
+    *,
+    task_id: str,
+    destination_root: Path,
+    config: TaskferryProviderConfig,
+    result_payload: Mapping[str, JsonValue] | None = None,
+    error_summary: Mapping[str, JsonValue] | None = None,
+) -> None:
+    destination_root.mkdir(parents=True, exist_ok=True)
+    manifest: dict[str, JsonValue] = {
+        "schema_version": "autosaddler-taskferry-trace-export/v1",
+        "taskferry_task_id": task_id,
+        "model": config.model,
+        "executor": config.executor,
+        "variant": config.variant,
+        "sensitive": True,
+        "transcript": f"Available via: taskferry result {task_id} --full",
+    }
+    if result_payload is not None:
+        manifest.update(
+            {
+                "status": _text(result_payload.get("status")),
+                "session_id": _text(result_payload.get("sessionId")),
+                "exit_code": _nested(result_payload, "exitCode"),
+                "incomplete": bool(result_payload.get("incomplete")),
+                "tokens": result_payload.get("tokens"),
+                "message": _text(result_payload.get("message")),
+            }
+        )
+        for key in ("failureReason", "failureDetail", "spawnError"):
+            value = result_payload.get(key)
+            if value is not None:
+                manifest[key] = value
+    else:
+        manifest.update(
+            {
+                "status": "unsettled",
+                **dict(error_summary or {}),
+            }
+        )
+    (destination_root / "export-manifest.json").write_text(
+        json.dumps(manifest, sort_keys=True, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Minimal TOON decoder for taskferry CLI output
+# ---------------------------------------------------------------------------
+
+_LITERALS = {"null": None, "true": True, "false": False}
+_NUMBER_RE = re.compile(r"^-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$")
+_ARRAY_HEADER_RE = re.compile(r"^(.+)\[(\d+)\]$")
+_KEY_VALUE_RE = re.compile(r"^([^:]+):\s?(.*)$")
+
+
+def _decode_toon(text: str) -> Mapping[str, JsonValue]:
+    """Decode the TOON object emitted on stdout by taskferry CLI commands.
+
+    Only the subset the CLI emits for dispatch/wait/result is supported:
+    objects with bare or JSON-quoted scalar values, nested objects, and
+    single-line arrays. Unknown shapes raise ValueError.
+    """
+    lines = [line for line in text.splitlines() if line.strip()]
+    if not lines:
+        raise ValueError("taskferry CLI produced empty output")
+    value, _ = _toon_block(lines, 0, 0)
+    if not isinstance(value, dict):
+        raise ValueError("taskferry CLI output must be a single TOON object")
+    return value
+
+
+def _toon_block(lines: list[str], index: int, indent: int) -> tuple[JsonValue, int]:
+    result: dict[str, JsonValue] = {}
+    count = len(lines)
+    while index < count:
+        line = lines[index]
+        current_indent = len(line) - len(line.lstrip(" "))
+        if current_indent < indent:
+            break
+        if current_indent != indent:
+            raise ValueError(f"unexpected indentation in taskferry CLI output: {line!r}")
+        content = line.strip()
+        match = _KEY_VALUE_RE.match(content)
+        if not match:
+            raise ValueError(f"unsupported line in taskferry CLI output: {line!r}")
+        key, value_text = match.group(1), match.group(2)
+        array_match = _ARRAY_HEADER_RE.match(key)
+        if array_match:
+            key = array_match.group(1)
+        if value_text == "":
+            if array_match:
+                raise ValueError(f"unsupported multiline array in taskferry CLI output: {key!r}")
+            child, index = _toon_block(lines, index + 1, indent + 2)
+            result[key] = to_json_value(child)
+            continue
+        if array_match:
+            result[key] = to_json_value(_toon_list(value_text))
+        else:
+            result[key] = _toon_scalar(value_text)
+        index += 1
+    return result, index
+
+
+def _toon_scalar(text: str) -> JsonValue:
+    if text == "":
+        return ""
+    if text in _LITERALS:
+        return _LITERALS[text]
+    if text.startswith('"'):
+        try:
+            value = json.loads(text)
+        except json.JSONDecodeError as error:
+            raise ValueError(f"invalid quoted string in taskferry CLI output: {text[:80]!r}") from error
+        return value
+    if _NUMBER_RE.match(text):
+        return float(text) if "." in text or "e" in text.lower() else int(text)
+    return text
+
+
+def _toon_list(text: str) -> list[JsonValue]:
+    parts: list[str] = []
+    current = ""
+    quoted = False
+    index = 0
+    while index < len(text):
+        char = text[index]
+        if char == "\\" and quoted and index + 1 < len(text):
+            current += text[index : index + 2]
+            index += 2
+            continue
+        if char == '"':
+            current += char
+            quoted = not quoted
+        elif char == "," and not quoted:
+            parts.append(current)
+            current = ""
+        else:
+            current += char
+        index += 1
+    parts.append(current)
+    return [_toon_scalar(part) for part in parts]

--- a/src/autosaddler/v2/providers/workspace_renderer.py
+++ b/src/autosaddler/v2/providers/workspace_renderer.py
@@ -146,6 +146,16 @@ COPILOT_CAPABILITY_TO_TOOLS: Mapping[Capability, tuple[str, ...]] = MappingProxy
     }
 )
 
+TASKFERRY_CAPABILITY_TO_TOOLS: Mapping[Capability, tuple[str, ...]] = MappingProxyType(
+    {
+        "read_workspace": ("read", "glob", "grep"),
+        "edit_workspace": ("write", "edit"),
+        "run_commands": ("bash",),
+        "load_skills": ("skill",),
+        "network": ("webfetch", "websearch"),
+    }
+)
+
 
 def claude_renderer() -> WorkspaceRenderer:
     return WorkspaceRenderer(
@@ -162,4 +172,13 @@ def copilot_renderer() -> WorkspaceRenderer:
         instruction_file="AGENTS.md",
         skill_directory=".copilot/skills",
         capability_tools=COPILOT_CAPABILITY_TO_TOOLS,
+    )
+
+
+def taskferry_renderer() -> WorkspaceRenderer:
+    return WorkspaceRenderer(
+        provider="taskferry",
+        instruction_file="AGENTS.md",
+        skill_directory=".opencode/skills",
+        capability_tools=TASKFERRY_CAPABILITY_TO_TOOLS,
     )

--- a/tests/v2/providers/test_provider_parity.py
+++ b/tests/v2/providers/test_provider_parity.py
@@ -33,6 +33,7 @@ from autosaddler.v2.providers.copilot import (
     _copilot_session_metrics,
     _export_copilot_session_state,
 )
+from autosaddler.v2.providers.taskferry import TaskferryAgentProvider
 
 
 class CapturingTransport:
@@ -475,6 +476,7 @@ def session_spec() -> SessionSpec:
     [
         (ClaudeAgentProvider, "CLAUDE.md", ".claude/skills"),
         (CopilotAgentProvider, "AGENTS.md", ".copilot/skills"),
+        (TaskferryAgentProvider, "AGENTS.md", ".opencode/skills"),
     ],
 )
 def test_provider_parity_preserves_semantic_session_assets(
@@ -523,7 +525,7 @@ def test_provider_parity_preserves_semantic_session_assets(
     assert rendered.allowed_tools
 
 
-@pytest.mark.parametrize("provider_type", [ClaudeAgentProvider, CopilotAgentProvider])
+@pytest.mark.parametrize("provider_type", [ClaudeAgentProvider, CopilotAgentProvider, TaskferryAgentProvider])
 def test_provider_rejects_skill_without_discovery_frontmatter(tmp_path: Path, provider_type) -> None:
     spec = replace(session_spec(), skills={"diagnose": "# Diagnose\n"})
     transport = CapturingTransport()
@@ -548,6 +550,7 @@ def test_provider_rejects_skill_without_discovery_frontmatter(tmp_path: Path, pr
     [
         (ClaudeAgentProvider, ".claude/skills"),
         (CopilotAgentProvider, ".copilot/skills"),
+        (TaskferryAgentProvider, ".opencode/skills"),
     ],
 )
 def test_provider_rejects_workspace_file_in_skill_directory(tmp_path: Path, provider_type, skill_root: str) -> None:

--- a/tests/v2/providers/test_taskferry_provider.py
+++ b/tests/v2/providers/test_taskferry_provider.py
@@ -1,0 +1,415 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import textwrap
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from autosaddler.v2.config.registry import _taskferry_provider
+from autosaddler.v2.providers.taskferry import (
+    TaskferryAgentProvider,
+    TaskferryCliTransport,
+    TaskferryProviderConfig,
+    _decode_toon,
+    _export_taskferry_session_state,
+    _taskferry_usage,
+)
+
+REAL_OPCODE_TOKENS = {
+    "input": 12,
+    "cacheRead": 4,
+    "cacheWrite": 2,
+    "output": 5,
+    "totalTokens": 17,
+    "cost": {"total": 0.42},
+}
+
+REAL_PI_TOKENS = {
+    "total": 26,
+    "input": 20,
+    "output": 6,
+    "reasoning": 3,
+    "cache": {"write": 9, "read": 15},
+}
+
+
+def test_decode_toon_object_nested_scalars_and_literals() -> None:
+    text = (
+        "id: oc_test123\n"
+        "status: queued\n"
+        "model: openai/gpt-5.6\n"
+        "exitCode: null\n"
+        "incomplete: false\n"
+        "startedAt: 2026-08-27T19:00:00Z\n"
+        "tokens:\n"
+        "  input: 12\n"
+        "  cacheRead: 4\n"
+    )
+    assert _decode_toon(text) == {
+        "id": "oc_test123",
+        "status": "queued",
+        "model": "openai/gpt-5.6",
+        "exitCode": None,
+        "incomplete": False,
+        "startedAt": "2026-08-27T19:00:00Z",
+        "tokens": {"input": 12, "cacheRead": 4},
+    }
+
+
+def test_decode_toon_quoted_strings_numbers_and_arrays() -> None:
+    text = (
+        "message: \"multi\\nline, with 'quote' \\\" and \\\\\"\n"
+        "cost: 0.0015\n"
+        "negative: -4\n"
+        'names[3]: a,b c,"d: e","x\\"y",1,"2"\n'
+        'empty: ""\n'
+    )
+    decoded = _decode_toon(text)
+    assert decoded["message"] == 'multi\nline, with \'quote\' " and \\'
+    assert decoded["cost"] == 0.0015
+    assert decoded["negative"] == -4
+    assert decoded["names"] == ["a", "b c", "d: e", 'x"y', 1, "2"]
+    assert decoded["empty"] == ""
+
+
+def test_decode_toon_bare_strings_that_look_like_numbers_stay_strings() -> None:
+    decoded = _decode_toon("message: 0.5.6 weird number-ish\n")
+    assert decoded == {"message": "0.5.6 weird number-ish"}
+
+
+def test_decode_toon_rejects_scalar_or_garbage_documents() -> None:
+    with pytest.raises(ValueError, match="single TOON object|unsupported line"):
+        _decode_toon("hello world\n")
+    with pytest.raises(ValueError, match="unexpected indentation"):
+        _decode_toon("  status: done\n")
+
+
+def test_taskferry_usage_opencode_shape_normalizes_tokens_and_cost() -> None:
+    usage = _taskferry_usage(
+        REAL_OPCODE_TOKENS,
+        TaskferryProviderConfig(model="openai/gpt-5.6", variant="default"),
+        duration_seconds=3.5,
+    )
+
+    assert len(usage) == 1
+    item = usage[0]
+    assert item.role == "optimizer"
+    assert item.model == "openai/gpt-5.6"
+    assert item.cached_input_tokens == 4
+    assert item.uncached_input_tokens == 14
+    assert item.input_tokens == 18
+    assert item.output_tokens == 5
+    assert item.total_tokens == 23
+    assert item.provider_reported_input_tokens == 12
+    assert item.provider_reported_total_tokens == 17
+    assert item.total_tokens_is_inferred is False
+    assert item.input_token_semantics == "excludes_cached_tokens"
+    assert item.provider_cost == 0.42
+    assert item.provider_cost_unit == "usd"
+    assert item.duration_seconds == 3.5
+    assert item.configured_settings == {"model": "openai/gpt-5.6", "variant": "default"}
+    assert item.status == "success"
+
+
+def test_taskferry_usage_pi_shape_reads_nested_cache() -> None:
+    item = _taskferry_usage(REAL_PI_TOKENS, TaskferryProviderConfig(model="openai/gpt-5.6"))[0]
+
+    assert item.cached_input_tokens == 15
+    assert item.uncached_input_tokens == 29
+    assert item.input_tokens == 44
+    assert item.output_tokens == 6
+    assert item.reasoning_tokens == 3
+    assert item.total_tokens == 50
+    assert item.provider_reported_total_tokens == 26
+    assert item.provider_cost is None
+    assert item.provider_cost_unit is None
+
+
+def test_taskferry_usage_without_tokens_or_cost_yields_zero_usage() -> None:
+    assert _taskferry_usage(None, TaskferryProviderConfig(model="openai/gpt-5.6")) == ()
+    assert _taskferry_usage("unexpected", TaskferryProviderConfig(model="openai/gpt-5.6")) == ()
+
+    item = _taskferry_usage({}, TaskferryProviderConfig(model="openai/gpt-5.6"))[0]
+    assert item.input_tokens == 0
+    assert item.output_tokens == 0
+    assert item.provider_reported_total_tokens is None
+    assert item.total_tokens_is_inferred is True
+    assert item.provider_cost is None
+    assert item.provider_cost_unit is None
+
+
+def test_taskferry_usage_clamps_reasoning_and_marks_incomplete() -> None:
+    item = _taskferry_usage(
+        {"input": 10, "output": 2, "reasoning": 9},
+        TaskferryProviderConfig(model="openai/gpt-5.6"),
+        incomplete=True,
+    )[0]
+
+    assert item.reasoning_tokens == 2
+    assert item.status == "failed"
+    assert item.usage_incomplete is True
+    assert item.provider_metadata == {"incomplete": True}
+
+
+def test_taskferry_config_validation() -> None:
+    with pytest.raises(ValueError, match="executor"):
+        TaskferryProviderConfig(model="openai/gpt-5.6", executor="fish")
+    assert TaskferryProviderConfig(model="openai/gpt-5.6", executor="pi").executor == "pi"
+    provider = TaskferryAgentProvider(transport=object())
+    assert provider._renderer.provider == "taskferry"
+
+
+def test_taskferry_provider_settings_validation() -> None:
+    with pytest.raises(ValueError, match="missing"):
+        _taskferry_provider({})
+    with pytest.raises(ValueError, match="extra"):
+        _taskferry_provider({"model": "openai/gpt-5.6", "bogus": 1})
+    with pytest.raises(TypeError, match="boolean"):
+        _taskferry_provider({"model": "openai/gpt-5.6", "sandboxed": "yes"})
+
+    provider = _taskferry_provider(
+        {"model": "openai/gpt-5.6", "variant": "ideas", "executor": "pi", "sandboxed": False}
+    )
+    transport = provider._transport
+    assert isinstance(transport, TaskferryCliTransport)
+    assert transport.config.variant == "ideas"
+    assert transport.config.executor == "pi"
+    assert transport.config.sandboxed is False
+
+
+def test_taskferry_export_manifest_writes_success_and_failure_paths(tmp_path: Path) -> None:
+    destination = tmp_path / "export"
+    _export_taskferry_session_state(
+        task_id="oc_fake123",
+        destination_root=destination,
+        config=TaskferryProviderConfig(model="openai/gpt-5.6", variant="default"),
+        result_payload={
+            "status": "done",
+            "sessionId": "sdk-session-1",
+            "exitCode": 0,
+            "incomplete": False,
+            "tokens": {"input": 12},
+            "message": '{"change":"done"}',
+        },
+    )
+    manifest = json.loads((destination / "export-manifest.json").read_text())
+    assert manifest["schema_version"] == "autosaddler-taskferry-trace-export/v1"
+    assert manifest["taskferry_task_id"] == "oc_fake123"
+    assert manifest["status"] == "done"
+    assert manifest["session_id"] == "sdk-session-1"
+    assert manifest["exit_code"] == 0
+    assert manifest["tokens"] == {"input": 12}
+    assert manifest["sensitive"] is True
+
+    failure_destination = tmp_path / "export-failed"
+    _export_taskferry_session_state(
+        task_id="oc_fake123",
+        destination_root=failure_destination,
+        config=TaskferryProviderConfig(model="openai/gpt-5.6"),
+        error_summary={"error_type": "TimeoutError", "error": "timed out"},
+    )
+    failed = json.loads((failure_destination / "export-manifest.json").read_text())
+    assert failed["status"] == "unsettled"
+    assert failed["error_type"] == "TimeoutError"
+
+
+FAKE_TASKSFERRY_CLI = textwrap.dedent(
+    r"""
+    #!/usr/bin/env python3
+    import json
+    import os
+    import sys
+    from pathlib import Path
+
+    state = Path(os.environ["FAKE_TF_STATE"])
+    command = sys.argv[1]
+    if command == "dispatch":
+        args = sys.argv[2:]
+        (state / "args.json").write_text(json.dumps(args))
+        prompt_index = args.index("--prompt")
+        assert args[prompt_index + 1] == "-"
+        (state / "prompt.txt").write_text(sys.stdin.read())
+        (state / "directory.txt").write_text(args[args.index("--directory") + 1])
+        (state / "model.txt").write_text(args[args.index("--model") + 1])
+        if (state / "fail-dispatch").exists():
+            print("dispatch exploded", file=sys.stderr)
+            sys.exit(2)
+        print("id: oc_fake123")
+        print("status: queued")
+        print("model: openai/gpt-5.6")
+    elif command == "wait":
+        if (state / "stall").exists():
+            print("id: oc_fake123")
+            print("status: running")
+        else:
+            print("id: oc_fake123")
+            print("status: done")
+    elif command == "result":
+        result_status = "done"
+        status_file = state / "result-status.txt"
+        if status_file.exists():
+            result_status = status_file.read_text().strip()
+        print("status: " + result_status)
+        print("sessionId: sdk-session-1")
+        print("message: " + json.dumps('{"change":"done"}'))
+        if result_status == "done":
+            print("tokens:")
+            print("  input: 12")
+            print("  cacheRead: 4")
+            print("  cacheWrite: 2")
+            print("  output: 5")
+            print("  totalTokens: 17")
+            print("  cost:")
+            print("    total: 0.42")
+        else:
+            print("failureReason: exploded")
+            print("exitCode: 1")
+    elif command == "cancel":
+        (state / "cancelled.txt").write_text(" ".join(sys.argv[2:]))
+        print("cancelled")
+    """
+)
+
+
+@pytest.fixture
+def fake_taskferry(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path, Path]:
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    script = tmp_path / "fake-taskferry"
+    script.write_text(FAKE_TASKSFERRY_CLI.lstrip("\n"))
+    script.chmod(0o755)
+    monkeypatch.setenv("FAKE_TF_STATE", str(state_dir))
+    return script, state_dir
+
+
+def session_state(tmp_path: Path) -> SimpleNamespace:
+    return SimpleNamespace(
+        workspace=tmp_path / "workspace",
+        system_context="Optimize only the declared candidate surface.",
+        task_prompt="Diagnose the training failures and emit one mutation.",
+        trace_dir=tmp_path / "traces",
+    )
+
+
+def test_taskferry_transport_dispatches_and_parses_result(
+    tmp_path: Path, fake_taskferry: tuple[Path, Path]
+) -> None:
+    script, state_dir = fake_taskferry
+    config = TaskferryProviderConfig(
+        model="openai/gpt-5.6",
+        variant="ideas",
+        executor="opencode",
+        executable=str(script),
+    )
+    session = session_state(tmp_path)
+    session.workspace.mkdir(parents=True)
+
+    outcome = asyncio.run(TaskferryCliTransport(config).run(session, 30))
+
+    assert outcome.raw_response == '{"change":"done"}'
+    assert outcome.usage_streamed is True
+    usage = outcome.usage[0]
+    assert usage.input_tokens == 18
+    assert usage.cached_input_tokens == 4
+    assert usage.uncached_input_tokens == 14
+    assert usage.output_tokens == 5
+    assert usage.total_tokens == 23
+    assert usage.provider_cost == 0.42
+    assert usage.provider_cost_unit == "usd"
+    assert usage.provider_correlation_id == "sdk-session-1"
+
+    dispatch_args = json.loads((state_dir / "args.json").read_text())
+    assert "--no-overlay" in dispatch_args
+    assert dispatch_args[dispatch_args.index("--class") + 1] == "autosaddler-v2"
+    assert dispatch_args[dispatch_args.index("--variant") + 1] == "ideas"
+    assert dispatch_args[dispatch_args.index("--executor") + 1] == "opencode"
+    assert (state_dir / "directory.txt").read_text() == str(session.workspace)
+    prompt = (state_dir / "prompt.txt").read_text()
+    assert session.system_context in prompt
+    assert session.task_prompt in prompt
+    assert "session_output_schema.json" in prompt
+    assert not (state_dir / "cancelled.txt").exists()
+
+    manifest = json.loads(
+        (session.trace_dir / "taskferry-session-state" / "export-manifest.json").read_text()
+    )
+    assert manifest["taskferry_task_id"] == "oc_fake123"
+    assert manifest["status"] == "done"
+    assert manifest["tokens"]["input"] == 12
+    assert "Diagnose" not in json.dumps(manifest)
+
+
+def test_taskferry_transport_without_sandbox_passes_no_sandbox_flag(
+    tmp_path: Path, fake_taskferry: tuple[Path, Path]
+) -> None:
+    script, state_dir = fake_taskferry
+    config = TaskferryProviderConfig(
+        model="openai/gpt-5.6",
+        sandboxed=False,
+        executable=str(script),
+    )
+    session = session_state(tmp_path)
+    session.workspace.mkdir(parents=True)
+
+    asyncio.run(TaskferryCliTransport(config).run(session, 30))
+
+    assert "--no-sandbox" in json.loads((state_dir / "args.json").read_text())
+    assert "--no-overlay" in json.loads((state_dir / "args.json").read_text())
+
+
+def test_taskferry_transport_fails_closed_on_crashed_task_and_cancels(
+    tmp_path: Path, fake_taskferry: tuple[Path, Path]
+) -> None:
+    script, state_dir = fake_taskferry
+    (state_dir / "result-status.txt").write_text("crashed")
+    config = TaskferryProviderConfig(model="openai/gpt-5.6", executable=str(script))
+    session = session_state(tmp_path)
+    session.workspace.mkdir(parents=True)
+
+    with pytest.raises(RuntimeError, match="crashed"):
+        asyncio.run(TaskferryCliTransport(config).run(session, 30))
+
+    assert (state_dir / "cancelled.txt").read_text() == "oc_fake123"
+    manifest = json.loads(
+        (session.trace_dir / "taskferry-session-state" / "export-manifest.json").read_text()
+    )
+    assert manifest["status"] == "crashed"
+    assert manifest["failureReason"] == "exploded"
+
+
+def test_taskferry_transport_times_out_when_wait_stalls_and_cancels(
+    tmp_path: Path, fake_taskferry: tuple[Path, Path]
+) -> None:
+    script, state_dir = fake_taskferry
+    (state_dir / "stall").write_text("")
+    config = TaskferryProviderConfig(model="openai/gpt-5.6", executable=str(script))
+    session = session_state(tmp_path)
+    session.workspace.mkdir(parents=True)
+
+    with pytest.raises(TimeoutError, match="did not settle"):
+        asyncio.run(TaskferryCliTransport(config).run(session, 30))
+
+    assert (state_dir / "cancelled.txt").read_text() == "oc_fake123"
+    manifest = json.loads(
+        (session.trace_dir / "taskferry-session-state" / "export-manifest.json").read_text()
+    )
+    assert manifest["status"] == "unsettled"
+    assert manifest["error_type"] == "TimeoutError"
+
+
+def test_taskferry_transport_raises_on_dispatch_failure(
+    tmp_path: Path, fake_taskferry: tuple[Path, Path]
+) -> None:
+    script, state_dir = fake_taskferry
+    (state_dir / "fail-dispatch").write_text("")
+    config = TaskferryProviderConfig(model="openai/gpt-5.6", executable=str(script))
+    session = session_state(tmp_path)
+    session.workspace.mkdir(parents=True)
+
+    with pytest.raises(RuntimeError, match="exit 2"):
+        asyncio.run(TaskferryCliTransport(config).run(session, 30))
+
+    assert not (state_dir / "cancelled.txt").exists()


### PR DESCRIPTION
## What

Adds a `taskferry` optimizer provider to the v2 engine alongside the existing `fake`/`claude`/`copilot` providers. Each optimizer session is dispatched as its own sandboxed TaskFerry task (opencode or pi worker on an external model), waits for settlement, and records reported tokens/cost in the usage ledger.

## How

- `src/autosaddler/v2/providers/taskferry.py` — `TaskferryProviderConfig`, `TaskferryAgentProvider`, and `TaskferryCliTransport`:
  - dispatches via `taskferry dispatch --prompt - --directory <workspace> --model <model> --no-overlay --class autosaddler-v2`, waits with a bounded `wait --timeout`, and pulls `result --fields message,tokens,cost,...`
  - minimal TOON decoder for the CLI's stdout contract (objects, nested objects, arrays, JSON-quoted strings) — verified against real CLI output
  - usage normalization for both executor token shapes (opencode `cacheRead/cacheWrite/totalTokens`; pi nested `cache.write/cache.read`), mapped to the same invariants as claude/copilot (`cached + uncached == input`, `input + output == total`, `provider_reported_*`, `provider_cost`/`usd`)
  - `--no-overlay` so the worker's writes land directly in the AutoSaddler-owned session workspace and the structured output file is readable on settlement
  - provenance/trace export manifest under `trace_dir/taskferry-session-state/export-manifest.json` (schema version, task id, session id, tokens, status, error detail)
  - fail-closed: non-`done` status raises with failure detail; unsettled after timeout raises `TimeoutError`; best-effort `taskferry cancel` on error paths
- `src/autosaddler/v2/providers/workspace_renderer.py` — `taskferry_renderer()` (AGENTS.md instruction file, `.opencode/skills` skill dir, capability→tool mapping)
- `src/autosaddler/v2/config/registry.py` — `taskferry` provider registration; settings keys `model` (required), `variant`, `executor`, `sandboxed`
- `tests/v2/providers/test_taskferry_provider.py` — decoder, usage mapping, export manifest, end-to-end transport against a fake taskferry CLI (dispatch args, prompt on stdin, timeout/cancel, crash paths)
- parity tests extended to cover the taskferry renderer
- README provider section

## Verification

- `uv run pytest tests/` — 225 passed
- `uv run ruff check src tests` — clean
- live smoke test against the running daemon with `alibaba-tknplan/deepseek-v4-flash-0731` (pi executor): dispatched, settled, parsed, and normalized real output (`OK`, 2867 total tokens, session id captured, manifest written)

## Notes

- No new Python dependencies; the provider shells out to the `taskferry` CLI (`executable` config key, default `taskferry`).
- The token-plan route used for the smoke test is the account's current cheapest live route, not a recommendation baked into code; config defaults to `openai/gpt-5.6` and should be overridden per environment.